### PR TITLE
Add BITCOIN_CLI_PATH env var and update bitcoin-cli usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,6 @@ RPC_USER=*****
 RPC_PASSWORD=*****
 RPC_PORT=18443
 
-# Windows: add your full bitcoin-cli.exe path "C:/path/to/bitcoin-cli.exe"
-# e.g. BITCOIN_CLI_PATH=/mnt/c/home/user/bitcoin-cli.exe
-BITCOIN_CLI_PATH=
+# Uncomment and set the path if bitcoin-cli is not in your system PATH, mainly for Windows users
+# i.e: BITCOIN_CLI_PATH=/path/to/bitcoin-cli.exe
+# BITCOIN_CLI_PATH=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+NETWORK=regtest
+RPC_HOST=127.0.0.1
+RPC_USER=*****
+RPC_PASSWORD=*****
+RPC_PORT=18443
+
+# Windows: add your full bitcoin-cli.exe path "C:/path/to/bitcoin-cli.exe"
+# e.g. BITCOIN_CLI_PATH=/mnt/c/home/user/bitcoin-cli.exe
+BITCOIN_CLI_PATH=

--- a/src/config/process.ts
+++ b/src/config/process.ts
@@ -3,3 +3,4 @@ export const RPC_HOST = process.env.RPC_HOST || "127.0.0.1";
 export const RPC_USER = process.env.RPC_USER || "polaruser";
 export const RPC_PASSWORD = process.env.RPC_PASSWORD || "polarpass";
 export const RPC_PORT = process.env.RPC_PORT || 18443;
+export const BITCOIN_CLI_PATH = process.env.BITCOIN_CLI_PATH || "bitcoin-cli";

--- a/src/lib/bitcoin-cli.ts
+++ b/src/lib/bitcoin-cli.ts
@@ -20,6 +20,7 @@ import {
   RPC_PASSWORD,
   NETWORK,
   RPC_PORT,
+  BITCOIN_CLI_PATH,
 } from "@/config/process";
 
 const execAsync = promisify(exec);
@@ -44,7 +45,7 @@ export class BitcoinCLI {
   private buildBaseCommand(): string {
     const networkFlag =
       this.config.network === "mainnet" ? "" : `-${this.config.network}`;
-    return `bitcoin-cli ${networkFlag} -rpcconnect=${this.config.rpchost} -rpcuser=${this.config.rpcuser} -rpcpassword=${this.config.rpcpassword} -rpcport=${this.config.rpcport} -rpcwallet=extheoisah`;
+    return `${BITCOIN_CLI_PATH} ${networkFlag} -rpcconnect=${this.config.rpchost} -rpcuser=${this.config.rpcuser} -rpcpassword=${this.config.rpcpassword} -rpcport=${this.config.rpcport} -rpcwallet=extheoisah`;
   }
 
   private async executeCommand<T>(command: string): Promise<T> {

--- a/src/lib/bitcoin-cli.ts
+++ b/src/lib/bitcoin-cli.ts
@@ -45,8 +45,9 @@ export class BitcoinCLI {
   private buildBaseCommand(): string {
     const networkFlag =
       this.config.network === "mainnet" ? "" : `-${this.config.network}`;
-    return `${BITCOIN_CLI_PATH} ${networkFlag} -rpcconnect=${this.config.rpchost} -rpcuser=${this.config.rpcuser} -rpcpassword=${this.config.rpcpassword} -rpcport=${this.config.rpcport} -rpcwallet=extheoisah`;
-  }
+    const sanitizedBitcoinCliPath = `"${BITCOIN_CLI_PATH.replace(/"/g, '\\"')}"`;
+	    return `${sanitizedBitcoinCliPath}${networkFlag ? " " + networkFlag : ""} -rpcconnect=${this.config.rpchost} -rpcuser=${this.config.rpcuser} -rpcpassword=${this.config.rpcpassword} -rpcport=${this.config.rpcport} -rpcwallet=extheoisah`;
+    }
 
   private async executeCommand<T>(command: string): Promise<T> {
     try {


### PR DESCRIPTION
Introduces a BITCOIN_CLI_PATH environment variable to allow configuration of the bitcoin-cli executable path, with updates to .env.example and process config. The BitcoinCLI class now uses this variable to determine which bitcoin-cli binary to invoke, improving cross-platform compatibility.